### PR TITLE
Implement joystick sanity checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,11 +71,40 @@ class Main(engine.Game):
 		
 		#Joystick initialization
 		if (pygame.joystick.get_count() > 0): #Seems like there is a virtual joystick in some computer
-			print "Detected Joystick"
-			base.has_joy = True
-			base.joy = pygame.joystick.Joystick(0)
-			base.joy.init()
-
+			for joy_id in range(pygame.joystick.get_count()):
+				base.joy = pygame.joystick.Joystick(joy_id)
+				if pygame.version.vernum[0] < 2:
+					# Deprecated since version 2.0.0 of pygame.
+					base.joy.init()
+				# Need to check whether the joystick is functional or not.
+				horz_test = False
+				vert_test = False
+				if base.joy.get_numbuttons() < 2:
+					# No point in using the joystick if it is lacking buttons.
+					pass
+				elif base.joy.get_numaxes() >= 2:
+					horz_test = abs(base.joy.get_axis(0)) < 0.1
+					vert_test = abs(base.joy.get_axis(1)) < 0.1
+				else:
+					pass
+				
+				if horz_test and vert_test:
+					print "Valid Joystick Detected: #" + str(joy_id)
+					base.has_joy = True
+					break
+				else:
+					base.joy.quit()
+					base.joy = None
+					print
+					print "Joystick #" + str(joy_id) + " has been disabled, as it appeared faulty."
+					print "If the Joystick is known to be working, check if a button was being pushed down during startup."
+					print "If it is still not working, please file a bug at https://github.com/TechPowerAwaits/Speckpater."
+					print
+			if not base.has_joy:
+				print
+				print "No Valid Joysticks Detected."
+				print
+		
 		print self.settings
 		print base.DATA
 	

--- a/player.py
+++ b/player.py
@@ -227,12 +227,10 @@ class Player(Sprite):
 			joy["right"] = base.joy.get_axis(0) > 0.1
 			joy["one"] = base.joy.get_button(0)
 			joy["two"] = base.joy.get_button(1)
-			joy["twelve"] = base.joy.get_button(11) #'A' button on Xbox 360 controller with MacOSX driver
-			#joy["thirteen"] = base.joy.get_button(12)
-			#print joy["twelve"]
+			if base.joy.get_numbuttons() > 11:
+				joy["twelve"] = base.joy.get_button(11) #'A' button on Xbox 360 controller with MacOSX driver
 		
 		self.upOrDownKeys = keys[K_DOWN] or keys[K_UP] or joy["down"] or joy["up"]
-		#self.upOrDownKeys = keys[K_DOWN] or keys[K_UP]
 		prevState = self.state
 		
 		if keys[K_m]:
@@ -285,7 +283,6 @@ class Player(Sprite):
 			self.state = STAND
 			
 		if((keys[K_t] or joy["one"]) and self.actionTimer == 0 and base.numBananas > 0):
-		#if (keys[K_t] and self.actionTimer == 0 and base.numBananas > 0):
 			base.numBananas -= 1
 			s = items.Banana(game, self.rect)
 			game.sprites.append(s)
@@ -298,8 +295,6 @@ class Player(Sprite):
 			self.actionTimer -= 1
 
 		if ((keys[K_SPACE] or joy["two"] or joy["twelve"]) and self.jumpAllowed and (((self.on_ground == 1) and (self.state != JUMP)) or (self.state == CLIMB))):
-			 
-		#if (keys[K_SPACE] and self.jumpAllowed and (((self.on_ground == 1) and (self.state != JUMP)) or (self.state == CLIMB))):
 			self.jumpAllowed = False
 			self.dy = -JUMP_SPEED
 			self.state = JUMP
@@ -309,7 +304,6 @@ class Player(Sprite):
 				self.dy = self.dy * 4 / 5
 		
 		if not (keys[K_SPACE] or joy["two"]):
-		#if not keys[K_SPACE]:
 			self.jumpAllowed = True
 	
 		## We check to see if we're trying to walk in one direction or another


### PR DESCRIPTION
Part of the _Disable invalid joysticks_ commit does not work properly. More specifically, joysticks triggering an uncontrollable direction change aren't detected. This behaviour was noticed in a GNOME Boxes virtual machine, so the machine doesn't actually have a joystick. Indeed, disabling joystick support does fix the problem, and maybe it would be a good idea to add a command line option to disable a joystick. However, it still would be a nice feature to block non-functioning joysticks automatically.